### PR TITLE
improve: companion handler fd closing; fix: PIPE signal handling

### DIFF
--- a/zygiskd/src/.gitignore
+++ b/zygiskd/src/.gitignore
@@ -1,2 +1,0 @@
-zygiskd64
-zygiskd32

--- a/zygiskd/src/dl.c
+++ b/zygiskd/src/dl.c
@@ -11,77 +11,47 @@
 #include <stdint.h>
 
 #include <android/log.h>
+#include <android/dlext.h>
 
 #include "companion.h"
 #include "utils.h"
 
-#define ANDROID_NAMESPACE_TYPE_SHARED 0x2
-#define ANDROID_DLEXT_USE_NAMESPACE 0x200
+#define __LOADER_ANDROID_CREATE_NAMESPACE_TYPE(name) struct android_namespace_t *(*name)( \
+  const char *name,                                                                      \
+  const char *ld_library_path,                                                           \
+  const char *default_library_path,                                                      \
+  uint64_t type,                                                                         \
+  const char *permitted_when_isolated_path,                                              \
+  struct android_namespace_t *parent,                                                    \
+  const void *caller_addr)
 
-typedef struct AndroidNamespace {
-  uint8_t _unused[0];
-} AndroidNamespace;
-
-typedef struct AndroidDlextinfo {
-  uint64_t flags;
-  void *reserved_addr;
-  size_t reserved_size;
-  int relro_fd;
-  int library_fd;
-  off64_t library_fd_offset;
-  AndroidNamespace *library_namespace;
-} AndroidDlextinfo;
-
-extern void *android_dlopen_ext(const char *filename, int flags, const AndroidDlextinfo *extinfo);
-
-typedef AndroidNamespace *(*AndroidCreateNamespaceFn)(
-  const char *name,
-  const char *ld_library_path,
-  const char *default_library_path,
-  uint64_t type,
-  const char *permitted_when_isolated_path,
-  AndroidNamespace *parent,
-  const void *caller_addr
-);
-
-void *android_dlopen(char *path, int flags) {
+void *dlopen_ext(const char* path, int flags) {
+  android_dlextinfo info = { 0 };
   char *dir = dirname(path);
-  struct AndroidDlextinfo info = {
-    .flags = 0,
-    .reserved_addr = NULL,
-    .reserved_size = 0,
-    .relro_fd = 0,
-    .library_fd = 0,
-    .library_fd_offset = 0,
-    .library_namespace = NULL,
-  };
 
-  void *handle = dlsym(RTLD_DEFAULT, "__loader_android_create_namespace");
-  AndroidCreateNamespaceFn android_create_namespace_fn = (AndroidCreateNamespaceFn)handle;
+  __LOADER_ANDROID_CREATE_NAMESPACE_TYPE(__loader_android_create_namespace) = (__LOADER_ANDROID_CREATE_NAMESPACE_TYPE( ))dlsym(RTLD_DEFAULT, "__loader_android_create_namespace");
 
-  AndroidNamespace *ns = android_create_namespace_fn(
-    path,
-    dir,
-    NULL,
-    ANDROID_NAMESPACE_TYPE_SHARED,
-    NULL,
-    NULL,
-    (const void *)&android_dlopen
-  );
+  struct android_namespace_t *ns = __loader_android_create_namespace == NULL ? NULL :
+              __loader_android_create_namespace(path, dir, NULL,
+                                                2, /* ANDROID_NAMESPACE_TYPE_SHARED */
+                                                NULL, NULL,
+                                                (void *)&dlopen_ext);
 
-  if (ns != NULL) {
+  if (ns) {
     info.flags = ANDROID_DLEXT_USE_NAMESPACE;
     info.library_namespace = ns;
 
-    LOGI("Open %s with namespace %p\n", path, (void *)ns);
+    LOGI("Open %s with namespace %p", path, (void *)ns);
   } else {
-    LOGI("Cannot create namespace for %s\n", path);
+    LOGW("Cannot create namespace for %s", path);
   }
 
-  void *result = android_dlopen_ext(path, flags, &info);
-  if (result == NULL) {
-    LOGE("Failed to dlopen %s: %s\n", path, dlerror());
+  void *handle = android_dlopen_ext(path, flags, &info);
+  if (handle) {
+    LOGI("dlopen %s: %p", path, handle);
+  } else {
+    LOGE("dlopen %s: %s", path, dlerror());
   }
 
-  return result;
+  return handle;
 }

--- a/zygiskd/src/dl.h
+++ b/zygiskd/src/dl.h
@@ -1,6 +1,6 @@
 #ifndef DL_H
 #define DL_H
 
-void *android_dlopen(char *path, int flags);
+void *dlopen_ext(char *path, int flags);
 
 #endif /* DL_H */

--- a/zygiskd/src/utils.c
+++ b/zygiskd/src/utils.c
@@ -228,11 +228,11 @@ ssize_t write_fd(int fd, int sendfd) {
 
 int read_fd(int fd) {
   char cmsgbuf[CMSG_SPACE(sizeof(int))];
-  char buf[1] = { 0 };
-  
+
+  int cnt = 1;
   struct iovec iov = {
-    .iov_base = buf,
-    .iov_len = 1
+    .iov_base = &cnt,
+    .iov_len = sizeof(cnt)
   };
 
   struct msghdr msg = {
@@ -242,7 +242,7 @@ int read_fd(int fd) {
     .msg_controllen = sizeof(cmsgbuf)
   };
 
-  ssize_t ret = recvmsg(fd, &msg, 0);
+  ssize_t ret = recvmsg(fd, &msg, MSG_WAITALL);
   if (ret == -1) {
     LOGE("recvmsg: %s\n", strerror(errno));
 

--- a/zygiskd/src/utils.h
+++ b/zygiskd/src/utils.h
@@ -9,12 +9,18 @@
 #define CONCAT_(x,y) x##y
 #define CONCAT(x,y) CONCAT_(x,y)
 
-#define LOGI(...)                                                                           \
-  __android_log_print(ANDROID_LOG_INFO, lp_select("zygiskd32", "zygiskd64"), __VA_ARGS__);  \
+#define LOG_TAG lp_select("zygiskd32", "zygiskd64")
+
+#define LOGI(...)                                              \
+  __android_log_print(ANDROID_LOG_INFO, LOG_TAG, __VA_ARGS__); \
   printf(__VA_ARGS__);
 
-#define LOGE(...)                                                                            \
-  __android_log_print(ANDROID_LOG_ERROR , lp_select("zygiskd32", "zygiskd64"), __VA_ARGS__); \
+#define LOGW(...)                                                \
+  __android_log_print(ANDROID_LOG_WARN, LOG_TAG, __VA_ARGS__);   \
+  printf(__VA_ARGS__);
+
+#define LOGE(...)                                                \
+  __android_log_print(ANDROID_LOG_ERROR , LOG_TAG, __VA_ARGS__); \
   printf(__VA_ARGS__);
 
 #define ASSURE_SIZE_WRITE(area_name, subarea_name, sent_size, expected_size)                                     \


### PR DESCRIPTION
This commit improves how we decide to close the fd that connects the injected module with the companion, avoiding both double close and fd leaks.

## Changes

Write here about the changes you've made

## Why 

Write here why you think this should be merged

## Checkmarks

- [ ] The modified functions have been tested.
- [ ] Used the same indentation as the rest of the project.
- [ ] Updated documentation (changelog).

## Additional information

If you have any additional information, write it here
